### PR TITLE
Build with Ruby 3.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: '3.1'
           bundler-cache: true
 
       - run: bundle exec jekyll build


### PR DESCRIPTION
For now, avoid Ruby 3.2.